### PR TITLE
Fix a DB error caused by non unique table alias because table was bei…

### DIFF
--- a/CRM/Yhvrequestform/BAO/Query/VolunteerApplication.php
+++ b/CRM/Yhvrequestform/BAO/Query/VolunteerApplication.php
@@ -24,7 +24,7 @@ class CRM_Yhvrequestform_BAO_Query_VolunteerApplication extends CRM_Contact_BAO_
 
   public function from($name, $mode, $side) {
 
-    if ($mode == CRM_Contact_BAO_Query::MODE_CONTACTS) {
+    if ($mode == CRM_Contact_BAO_Query::MODE_CONTACTS && $name == 'volunteer_timetable') {
       return "$side JOIN civicrm_volunteer_timetable volunteer_timetable ON volunteer_timetable.entity_id = contact_a.id AND entity_table = 'civicrm_contact'";
     }
   }
@@ -62,6 +62,7 @@ class CRM_Yhvrequestform_BAO_Query_VolunteerApplication extends CRM_Contact_BAO_
 
     $query->_qill[$grouping][] = ts($field['title'])." - '$qillValue'";
     $searchValue = explode('_', $field['name']);
+    $query->_tables['volunteer_timetable'] = $query->_whereTables['volunteer_timetable'] = 1;
     $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("volunteer_timetable.day", $op, $searchValue[0], "Integer");
     $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("volunteer_timetable.time", $op, $searchValue[1], "Integer");
     $query->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause("volunteer_timetable.number_of_volunteers", $op, 1, "Integer");


### PR DESCRIPTION
…ng added to the query multiple times

Whilst testing the ACL I found that if you did a search as a mailing ACLed user, and filtered on just a mailing name there was a DB error being generated due to non unique table alias.

ping @Edzelopez 